### PR TITLE
Added status to route endpoint metadata.

### DIFF
--- a/metadata/route.go
+++ b/metadata/route.go
@@ -46,6 +46,9 @@ type EndpointRoute struct {
 	// that requests get to this endpoint. For API endpoints, it's the request path
 	// like "/user/{ID}" and for event endpoints, it's the subscription key like "FooService.Save".
 	Path string
+	// Status passes along the route's HTTP ### value from doc options when applicable. This is
+	// automatically set to 200 for event-based routes for a consistent "OK nothing went wrong" default.
+	Status int
 	// Roles are used for role-based security where you can say that this endpoint requires the user/caller
 	// to have either "admin.write" or "group.write" privileges. When defining your services, you can parameterize
 	// your roles such as "group.{ID}.write", but the ones stored in this slice should have already been

--- a/metadata/route_test.go
+++ b/metadata/route_test.go
@@ -44,6 +44,7 @@ func (suite *RouteSuite) TestWithRoute() {
 		Type:        "3",
 		Method:      "4",
 		Path:        "5",
+		Status:      204,
 	}
 	ctx = metadata.WithRoute(ctx, route)
 	suite.Equal(route, metadata.Route(ctx))

--- a/services/gateways/apis/middleware.go
+++ b/services/gateways/apis/middleware.go
@@ -20,7 +20,7 @@ type HTTPMiddlewareFuncs []HTTPMiddlewareFunc
 //
 //	middlewareFuncs := HTTPMiddlewareFuncs{A, B, C}
 //	middlewareFuncs = middlewareFuncs.Append(D, E, F)
-//	// middlewareFuncs ==> {A, B, C, D, E, F}
+//	middlewareFuncs ==> {A, B, C, D, E, F}
 func (funcs HTTPMiddlewareFuncs) Append(functions ...HTTPMiddlewareFunc) HTTPMiddlewareFuncs {
 	return append(funcs, functions...)
 }
@@ -79,6 +79,7 @@ func restoreMetadataEndpoint(endpoint services.Endpoint, route services.Endpoint
 			Type:        route.GatewayType.String(),
 			Method:      route.Method,
 			Path:        route.Path,
+			Status:      route.Status,
 		})
 		next(w, req.WithContext(ctx))
 	}

--- a/services/gateways/events/gateway.go
+++ b/services/gateways/events/gateway.go
@@ -143,6 +143,7 @@ func (gw *Gateway) toStreamHandler(endpoint services.Endpoint, route services.En
 			Type:        gw.Type().String(),
 			Method:      route.Method,
 			Path:        route.Path,
+			Status:      route.Status,
 		})
 
 		if _, err := endpoint.Handler(ctx, serviceRequest); err != nil {

--- a/services/server.go
+++ b/services/server.go
@@ -194,6 +194,7 @@ func (server *Server) Invoke(ctx context.Context, serviceName string, methodName
 		ctx = metadata.WithRoute(ctx, metadata.EndpointRoute{
 			ServiceName: serviceName,
 			Name:        methodName,
+			Status:      200,
 		})
 		return endpoint.Handler(ctx, req)
 	}


### PR DESCRIPTION
Added a `Status` attribute to the `metadata.Route()` info struct. This helps loggers and other tracing tools identify what the intended status code should be.